### PR TITLE
removed unrecognizable spaces from README

### DIFF
--- a/04_testing_and_cicd/01_testing_and_validation/README.md
+++ b/04_testing_and_cicd/01_testing_and_validation/README.md
@@ -17,55 +17,55 @@ Then, using `my_assert`, complete the tests for the functions provided. Please s
 #include <vector>
 #include <string>
 #include <algorithm>
-​
+
 /*----These functions do not need to be changed----*/
-​​
+
 bool contains(const std::string& name, const std::vector<std::string>& list_of_names) {
     return std::find(list_of_names.begin(), list_of_names.end(), name) != list_of_names.end();
 }
-​
+
 void add_name(const std::string& name, std::vector<std::string>& list_of_names) {
     list_of_names.push_back(name);
 }
-​
+
 int add_two(int num) {
     return num + 2;
 }
-​
+
 double divide_by_two(double num) {
     return num / 2;
 }
-​
+
 std::string greeting(const std::string& name, double num) {
     std::string message {"Hello, " + name + ". It is " + std::to_string(num) + " degrees warmer today than yesterday"};
     return message;
 }
-​
+
 /*----Your code here----*/
 /*----Difficulty: Mt. Fuji----*/
-​
+
 // define `my_assert` here, and use it for the subsequent tests
-​
+
 // make a test called `test_contains` for `contains` here
-​​
+
 // make a test called `test_add_name` for `add_name` here
-​
+
 // make a test called `test_add_two` for `add_two` here
-​
+
 // make a test called `test_divide_by_two` for `divide_by_two` here
-​
+
 // make a test called `test_greeting` for `greeting` here
-​
-​
+
+
 /*----Difficulty: Mt Kilimanjaro----*/
-​
+
 // make a test called `test_my_assert_false` for `my_assert` to check if it correctly returns the given optional `msg` when the expression evaluates to false
-​
+
 // make a test called `test_my_assert_true` for `my_assert` to check if it correctly handles an expression that evaluates to true
-​
+
 /*----Difficulty: Mt. Everest----*/
-​
+
 // make a test called `test_complex_greeting` for the entire following expression using `my_assert`. If the expression fails, make sure to give a descriptive message for `msg` that describes how the expression fails.
 // greeting(contains("Frosty the Snowman", {"Oatmeal", "Prancer", "Rudolph", "Andy"}), divide_by_two(add_two(2)));
-​
+
 ```


### PR DESCRIPTION
# What I did

- removed spaces that throw error in VSCode in Mac

When copying and pasting code from README, VS code recognizes half spaces that it cannot recognize as proper ones. I removed them all.